### PR TITLE
Fix: Currency with baseValue > 1 gives wrong converted value

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,43 +1,46 @@
 # forex
 
-A cli tool to check the foreign exchange rates against Nepal's currency using Nepal Rastra Bank's [api](https://www.nrb.org.np/exportForexJSON.php).
+A cli tool to check the foreign exchange rates against Nepal's currency using Nepal Rastra Bank's [API](https://www.nrb.org.np/exportForexJSON.php).
 
 ## Installation
 
 You can install `forex` by running:
 
-```
+```sh
 $ go get github.com/aviskarkc10/forex
 ```
 
 ## Usage
 
-To view the available commands run:
+To view the available commands, run:
 
-```
+```sh
 $ forex
 ```
 
-To view the foreign exchange rates of all the available countries run
+To view the foreign exchange rates of all the available countries, run:
 
-```
-$ forex list # or forex l
+```sh
+$ forex list or forex l
 ```
 
-To convert a foreign currency to NPR run:
+To convert a foreign currency to NPR, run:
 
-```
+```sh
 $ forex convert <amount> <currency>
 ```
 
-
 For example:
 
-```
+```sh
 # Convert 1 American dollar to NPR
-$ forex convert 1 USD # or forex c 1 USD
+$ forex convert 1 USD or forex c 1 USD
+1.00 USD -> 113.34 NPR
+
+$ forex convert 1 INR or forex c 1 INR
+1.00 INR -> 1.60 NPR
 ```
 
-# LICENSE
+## LICENSE
 
 [MIT](LICENSE)

--- a/main.go
+++ b/main.go
@@ -129,9 +129,10 @@ func convert(c *cli.Context) {
 		os.Exit(1)
 	}
 
-	buyingValue, _ := strconv.ParseFloat(selectedCurrency.TargetBuy, 64)
+	unitRate := getUnitRate(selectedCurrency)
+	buyingValue := amt * unitRate
 
-	fmt.Printf("%.2f %s -> %.2f NPR\n", amt, currency, amt*buyingValue)
+	fmt.Printf("%.2f %s -> %.2f NPR\n", amt, currency, buyingValue)
 }
 
 // Validate arguments for currency and amount when converting to NPR.
@@ -164,4 +165,14 @@ func getSelectedCurrency(rates []Currency, currency string) Currency {
 	}
 
 	return selectedCurrency
+}
+
+// Get unit rate of a currency
+func getUnitRate(rate Currency) float64 {
+	baseValue, _ := strconv.ParseFloat(rate.BaseValue, 64)
+	targetBuy, _ := strconv.ParseFloat(rate.TargetBuy, 64)
+
+	unitRate := float64(targetBuy) / float64(baseValue)
+
+	return unitRate
 }


### PR DESCRIPTION
## Changes

**Problem**

- The currency with base value > 1 gives wrong converted value

  ```bash
  # For e.g.
  $ forex convert 10 INR
  10.00 INR -> 1600.00 NPR  # should be 16.00 NPR

  $ forex convert 10 JPY
  10.00 JPY -> 105.80 NPR # should be 10.58 NPR
  ```

This is because the given amount is directly multiplied with the base value from the NRB's API. And, few of the base values in the API are not a unit.

**Solution**

- First, calculate the unit rate and then perform the multiplication to give the correct output

  ```sh
  $ forex convert 10 INR
  10.00 INR -> 16.00 NPR

  $ forex convert 10 JPY
  10.00 JPY -> 10.58 NPR
  ```

* Some updates on README too :smiley: 